### PR TITLE
用 qs 代替 querystring 做 query 解析

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -7,7 +7,7 @@
 var contentType = require('content-type');
 var stringify = require('url').format;
 var parse = require('parseurl');
-var qs = require('querystring');
+var qs = require('qs');
 var typeis = require('type-is');
 var fresh = require('fresh');
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "on-finished": "^2.3.0",
     "parseurl": "^1.3.0",
     "path-to-regexp": "^1.2.1",
+    "qs": "^6.2.0",
     "require-dir": "^0.3.0",
     "resolve-keypath": "^1.1.0",
     "statuses": "^1.2.1",


### PR DESCRIPTION
querystring 对数组的解析不太方便，比如 a[0]='tom'&a[1]='jerry'
会被解析为 { 'a[0]': 'tom', 'a[1]': 'jerry' }

而 qs 会解析为 { 'a': ['tom', 'jerry'] }
