### PR TITLE
improve the priority of routes

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -117,7 +117,7 @@ methods.forEach(function (method) {
     if (typeof handler === 'string' && this.options.controllerPrefix) {
       handler = `${this.options.controllerPrefix}/${handler}`;
     }
-    this.stack.push(new Route(method, path, handler, options));
+    this.stack.unshift(new Route(method, path, handler, options));
   };
 });
 

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -58,6 +58,9 @@ class Router {
     memberRouter.patch('', `${controller}#patch`);
     memberRouter.delete('', `${controller}#destroy`);
 
+    // lower the priority of member router
+    collectionRouter.stack.push(collectionRouter.stack.shift());
+
     return this;
   }
 
@@ -117,7 +120,7 @@ methods.forEach(function (method) {
     if (typeof handler === 'string' && this.options.controllerPrefix) {
       handler = `${this.options.controllerPrefix}/${handler}`;
     }
-    this.stack.unshift(new Route(method, path, handler, options));
+    this.stack.push(new Route(method, path, handler, options));
   };
 });
 


### PR DESCRIPTION
之前如果定义了

``` javascript
router.resource('file', (member, collection) => {
  collection.get('/starred');
});
```

生成的 Router 结构是这样的：

``` javascript
Router</files> {
  stack: [
    Router</:file> {
      Route<GET />
    },
    Route<GET /starred>
  ]
}
```

`GET /files/:file` 优先级会高于 `GET /files/starred`，绝大部分情况下这个优先级正好相反，所以这里对于 `resource` 做了特殊处理，保证 collection 永远比 member 优先。
