### PR TITLE
pref: skip router when prefix not match

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -21,18 +21,26 @@ class Router {
     }
     if (parent) {
       this.parent = parent;
-      if (parent.options.middleware.length) {
-        this.options.middleware = parent.options.middleware.concat(this.options.middleware);
+
+      while (parent) {
+        this.prefix = parent.prefix + this.prefix;
+        parent = parent.parent;
       }
-      if (parent.options.controllerPrefix) {
+
+      if (this.parent.options.middleware.length) {
+        this.options.middleware = this.parent.options.middleware.concat(this.options.middleware);
+      }
+      if (this.parent.options.controllerPrefix) {
         if (this.options.controllerPrefix) {
-          this.options.controllerPrefix = `${parent.options.controllerPrefix}/${this.options.controllerPrefix}`;
+          this.options.controllerPrefix = `${this.parent.options.controllerPrefix}/${this.options.controllerPrefix}`;
         } else {
-          this.options.controllerPrefix = parent.options.controllerPrefix;
+          this.options.controllerPrefix = this.parent.options.controllerPrefix;
         }
       }
-      parent.stack.push(this);
+      this.parent.stack.push(this);
     }
+
+    this.isPlainPrefix = this.prefix.indexOf(':') === -1;
   }
 
   resource(name, cb, options) {
@@ -90,6 +98,9 @@ class Router {
   }
 
   match(path, method) {
+    if (this.isPlainPrefix && !path.startsWith(this.prefix)) {
+      return;
+    }
     for (let i = 0; i < this.stack.length; i++) {
       const match = this.stack[i].match(path, method);
       if (match) {
@@ -101,11 +112,7 @@ class Router {
 
 methods.forEach(function (method) {
   Router.prototype[method] = function (path, handler, options) {
-    let parent = this;
-    while (parent) {
-      path = parent.prefix + path;
-      parent = parent.parent;
-    }
+    path = this.prefix + path;
     if (options) {
       if (options.middleware && this.options.middleware) {
         options.middleware = this.options.middleware.concat(options.middleware);

--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -20,24 +20,20 @@ class Router {
       this.options.middleware = [this.options.middleware];
     }
     if (parent) {
-      this.parent = parent;
+      this.prefix = parent.prefix + this.prefix;
 
-      while (parent) {
-        this.prefix = parent.prefix + this.prefix;
-        parent = parent.parent;
+      if (parent.options.middleware.length) {
+        this.options.middleware = parent.options.middleware.concat(this.options.middleware);
       }
-
-      if (this.parent.options.middleware.length) {
-        this.options.middleware = this.parent.options.middleware.concat(this.options.middleware);
-      }
-      if (this.parent.options.controllerPrefix) {
+      if (parent.options.controllerPrefix) {
         if (this.options.controllerPrefix) {
-          this.options.controllerPrefix = `${this.parent.options.controllerPrefix}/${this.options.controllerPrefix}`;
+          this.options.controllerPrefix = `${parent.options.controllerPrefix}/${this.options.controllerPrefix}`;
         } else {
-          this.options.controllerPrefix = this.parent.options.controllerPrefix;
+          this.options.controllerPrefix = parent.options.controllerPrefix;
         }
       }
-      this.parent.stack.push(this);
+      parent.stack.push(this);
+      this.parent = parent;
     }
 
     this.isPlainPrefix = this.prefix.indexOf(':') === -1;


### PR DESCRIPTION
现在匹配路由的规则是从 stack 里挨个匹配，比如：

``` javascript
[
  Router(prefix: '/members', stack: [
    Route(GET /:member)
  ]),
  Route(GET /collections)
]
```

之前需要匹配两个路由，现在会先检测外侧 Router 的 prefix 是否匹配，如果比匹配就不再对其 stack 遍历了。效果是匹配 /files/starred 时从原来要匹配 29 个路由减少到了 10 个。
