### PR TITLE
Make bay work with async function

### DIFF
--- a/application.js
+++ b/application.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const co = require('co');
 const _ = require('lodash');
 const http = require('http');
 const compose = require('./lib/compose');

--- a/application.js
+++ b/application.js
@@ -124,7 +124,7 @@ class BayApplication {
         let body
 
         if (typeof fn === 'function') {
-          body = yield fn()
+          body = yield fn.call(this)
         }
 
         if (typeof body !== 'undefined') {

--- a/lib/compose.js
+++ b/lib/compose.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const co = require('co');
+const isGeneratorFn = require('is-generator-fn');
+
+function compose (middleware) {
+  return function (ctx) {
+    return Promise.resolve().then(function () {
+      let index = -1;
+
+      return dispatch(0);
+
+      function dispatch(i) {
+        if (i <= index) {
+          throw new Error('next() called multiple times');
+        }
+
+        index = i;
+
+        let fn = middleware[i];
+
+        if (typeof fn === 'function') {
+          if (isGeneratorFn(fn)) {
+            fn = co.wrap(fn);
+          }
+
+          return fn.call(ctx, function (cb) {
+            if (typeof cb === 'function') {
+              return cb(null, dispatch(i + 1));
+            }
+            return dispatch(i + 1);
+          });
+        }
+      }
+    });
+  };
+}
+
+module.exports = compose;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "http-assert": "^1.1.1",
     "http-errors": "^1.3.1",
     "i": "^0.3.3",
-    "koa-compose": "^2.3.0",
+    "is-generator-fn": "^1.0.0",
     "koa-is-json": "^1.0.0",
     "lodash": "^3.10.1",
     "methods": "^1.1.1",


### PR DESCRIPTION
调整后支持三种形式：

```js
app.use(function * (next) {
  yield next
})

app.use(function * (next) {
  yield next()
})

app.use(async function (next) {
  await next()
})
```

因为 async 不可以 await generator 对象，所以在 async func 里只能进行 `next()`。

这种处理不会造成 breaking change。