### PR TITLE
Fix a issue when `controller.action` is a normal function

### DIFF
--- a/application.js
+++ b/application.js
@@ -124,7 +124,14 @@ class BayApplication {
         let body
 
         if (typeof fn === 'function') {
-          body = yield fn.call(this)
+          const ret = fn.call(this);
+
+          // function, promise, generator, array, or object
+          if (ret != null && (typeof ret === 'object' || typeof ret === 'function')) {
+            body = yield ret;
+          } else {
+            body = ret;
+          }
         }
 
         if (typeof body !== 'undefined') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bay",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "The framework",
   "main": "application.js",
   "directories": {


### PR DESCRIPTION
修复下列代码会导致 `You may only yield a function, promise, generator, array, or object, but the following object was passed` 错误

```
class Home extends Controller {
  index () {
    return 'foo'
  }
}
```