### PR TITLE
Feature: able to add route by `router.add()`

### DIFF
--- a/lib/router/router.js
+++ b/lib/router/router.js
@@ -107,24 +107,32 @@ class Router {
       }
     }
   }
+
+  add (methods, path, handler, options) {
+    create(this, methods, path, handler, options);
+  }
 }
 
 methods.forEach(function (method) {
   Router.prototype[method] = function (path, handler, options) {
-    path = this.prefix + path;
-    if (options) {
-      if (options.middleware && this.options.middleware) {
-        options.middleware = this.options.middleware.concat(options.middleware);
-      }
-      options = _.defaults(options, this.options.middleware);
-    } else {
-      options = this.options;
-    }
-    if (typeof handler === 'string' && this.options.controllerPrefix) {
-      handler = `${this.options.controllerPrefix}/${handler}`;
-    }
-    this.stack.push(new Route(method, path, handler, options));
+    create(this, method, path, handler, options);
   };
 });
 
 module.exports = Router;
+
+function create (router, method, path, handler, options) {
+  path = router.prefix + path;
+  if (options) {
+    if (options.middleware && router.options.middleware) {
+      options.middleware = router.options.middleware.concat(options.middleware);
+    }
+    options = _.defaults(options, router.options.middleware);
+  } else {
+    options = router.options;
+  }
+  if (typeof handler === 'string' && router.options.controllerPrefix) {
+    handler = `${router.options.controllerPrefix}/${handler}`;
+  }
+  router.stack.push(new Route(method, path, handler, options));
+}


### PR DESCRIPTION
问题是这样的：

1. bay 在 `No route matches` 时[不会执行 `app.use()` 添加的 middlwares](https://github.com/shimohq/bay/blob/master/application.js#L80)
2. `OPTIONS` 被 `router.options` 给[替换掉了](https://github.com/shimohq/bay/blob/master/lib/router/router.js#L12)

所以导致一个很尴尬的事情：没办法给 CORS OPTIONS 做处理。

这个 PR 主要作用是添加一个 `.add()` 方法，可以自由添加路由：

```js
router.add(['get', 'post'], '/some/path', 'home#someAction')
```

